### PR TITLE
fix(operations): changed mirror displacement

### DIFF
--- a/iactrace/telescope/operations.py
+++ b/iactrace/telescope/operations.py
@@ -221,7 +221,7 @@ def apply_misalignment_to_group(telescope, group_idx: int, sigma_h: float, sigma
 
 
 def apply_displacement_to_group(telescope, group_idx: int, sigma_z: float, key: Array) -> Telescope:
-    """Apply random Gaussian distance adjustment to mirrors along the z-axis.
+    """Apply random Gaussian distance adjustment to mirrors along each mirror's local z-axis.
 
     Adds random perturbations to the z-coordinate of each mirror position
     in the specified group, drawn from a Gaussian distribution.
@@ -235,15 +235,19 @@ def apply_displacement_to_group(telescope, group_idx: int, sigma_z: float, key: 
     Returns:
         New Telescope with randomly displaced mirrors
     """
+    from ..core.transforms import euler_to_matrix
     group = telescope.mirror_groups[group_idx]
     n_mirrors = len(group)
 
-    # Generate random z displacements
+    # Generate random z displacements along each mirrors's local z-axis
     delta_z = jax.random.normal(key, shape=(n_mirrors,)) * sigma_z
 
-    # Apply to z-component of positions
-    current_positions = group.positions
-    new_positions = current_positions.at[:, 2].add(delta_z)
+    # Transform local z-axis of each mirror to world coordinates
+    rot = jax.vmap(euler_to_matrix)(group.rotations)
+    local_z_world = rot[:, :, 2]
+
+    # Apply displacement
+    new_positions = group.positions + delta_z[:, None] * local_z_world
 
     return _update_mirror_group_attr(
         telescope, group_idx, lambda g: g.positions, new_positions

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -170,6 +170,7 @@ class TestRandomPerturbations:
         assert not jnp.allclose(
             modified_tel.mirror_groups[0].positions[:, 2],
             simple_telescope.mirror_groups[0].positions[:, 2]
+        )
         
     def test_conic_error_preserves_mean(self, simple_telescope, random_key):
         """Conic error with zero sigma should preserve original values."""

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -150,15 +150,18 @@ class TestRandomPerturbations:
         assert jnp.isclose(jnp.std(delta_h), expected_sigma_h_deg, rtol=0.1)
         assert jnp.isclose(jnp.std(delta_v), expected_sigma_v_deg, rtol=0.1)
 
-    def test_displacement_affects_only_z(self, simple_telescope, random_key):
-        """Z-axis displacement should only affect z coordinates."""
+    def test_displacement_along_local_z_for_untilted_mirrors(
+        self, simple_telescope, random_key
+    ):
+        """For mirrors with zero rotation, local z == global z, so displacement
+        should only affect the world-frame z coordinate."""
         original_xy = simple_telescope.mirror_groups[0].positions[:, :2].copy()
 
         modified_tel = ops.apply_displacement_to_group(
             simple_telescope, 0, sigma_z=1.0, key=random_key
         )
 
-        # X and Y unchanged
+        # X and Y unchanged (mirrors have zero rotation in the fixture)
         assert jnp.allclose(
             modified_tel.mirror_groups[0].positions[:, :2],
             original_xy
@@ -167,8 +170,7 @@ class TestRandomPerturbations:
         assert not jnp.allclose(
             modified_tel.mirror_groups[0].positions[:, 2],
             simple_telescope.mirror_groups[0].positions[:, 2]
-        )
-
+        
     def test_conic_error_preserves_mean(self, simple_telescope, random_key):
         """Conic error with zero sigma should preserve original values."""
         original_conics = simple_telescope.mirror_groups[0].conics.copy()


### PR DESCRIPTION
Mirror displacement now goes along the local z-axis of each mirror, instead of along the global telescope axis, equivalent to simtel_array